### PR TITLE
大佬，发现您的项目引入了com.alibaba:fastjson@1.2.35组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com</groupId>
 	<artifactId>fms</artifactId>
@@ -16,7 +16,7 @@
 		<commons-dbcp.version>1.4</commons-dbcp.version>
 		<jstl.version>1.2</jstl.version>
 		<log4j.version>1.2.17</log4j.version>
-		<fastjson.version>1.2.35</fastjson.version>
+		<fastjson.version>1.2.69</fastjson.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<jackson.version>1.9.13</jackson.version>
 		<commons-fileupload.version>1.3.3</commons-fileupload.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Fastjson 1.2.25-1.2.43版本远程代码执行漏洞
缺陷组件：com.alibaba:fastjson@1.2.35
漏洞编号：
漏洞描述：Fastjson 是Java语言实现的快速JSON解析和生成器，在1.2.25-1.2.43版本攻击者可通过精心构造的JSON请求，绕过此前修复机制，远程执行任意代码。
漏洞原因：
AutoTypeSupport显式设置为True时，Fastjson会通过autoType来实例化json对象，由于通过基于黑名单的checkAutotype方法对@type字段进行安全性验证，攻击者可以绕过黑名单逻辑，并调用连接远程rmi主机，通过其中的恶意类执行代码。
影响范围：[1.2.25, 1.2.44)
最小修复版本：1.2.69
缺陷组件引入路径：com:fms@0.0.1-SNAPSHOT->com.alibaba:fastjson@1.2.35
```
另外我运行这个项目时，IDE的安全插件提示还有26个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pe135a